### PR TITLE
fix: resolve TypeError in FastMCP initialization

### DIFF
--- a/src/pdf_modifier_mcp/interfaces/mcp.py
+++ b/src/pdf_modifier_mcp/interfaces/mcp.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 mcp = FastMCP(
     "pdf-modifier-mcp",
-    description="PDF modification tools for reading, analyzing, and modifying PDF documents",
 )
 
 


### PR DESCRIPTION
He encontrado un error por el que el servidor MCP no se inicia debido a un argumento clave de descripción inesperado en el constructor FastMCP. 

Cambios:
He eliminado el argumento de descripción en src/pdf_modifier_mcp/interfaces/mcp.py para que coincida con la firma actual de la biblioteca.

He verificado que pdf-modifier-mcp ahora se inicia correctamente sin errores.

Nota: he tenido problemas con la longitud de la ruta en Poetry, para solucionarlo se puede usar un entorno virtual estándar: python -m venv venv && .\venv\Scripts\activate && pip install -e .