### PR TITLE
fix(release): update semantic-release config for v9 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ version_toml = ["pyproject.toml:project.version"]
 build_command = "poetry build"
 commit_message = "chore(release): v{version}"
 tag_format = "v{version}"
+branch = "master"
 
 [tool.semantic_release.changelog]
 template_dir = ".github/templates"
@@ -87,9 +88,8 @@ template_dir = ".github/templates"
 [tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
 
-[tool.semantic_release.branches.master]
-match = "master"
-prerelease = false
+[tool.semantic_release.remote]
+type = "github"
 
 [tool.semantic_release.publish]
 upload_to_vcs_release = true


### PR DESCRIPTION
- Replace deprecated branches.master table with branch = 'master'
- Add remote.type = 'github' required by v9