### PR TITLE
fix(release): use PAT to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,11 @@ jobs:
       - name: Semantic Release
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Use --no-push to avoid pushing to protected branch
-        # Tags are pushed separately and GitHub Release is created via publish
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          semantic-release version --no-push --no-commit
+          semantic-release version
           semantic-release publish
 
       - name: Publish to PyPI


### PR DESCRIPTION
## Summary
- Use RELEASE_TOKEN PAT instead of GITHUB_TOKEN
- Remove --no-push --no-commit flags to enable full release flow
- Allows pushing changelog and tags to protected master branch

## Test plan
- [ ] Merge and verify GitHub Release is created
- [ ] Verify CHANGELOG.md is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)