### PR TITLE
fix(release): use PAT token in checkout for git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Pass RELEASE_TOKEN to actions/checkout to configure git credentials
- This allows semantic-release to push to protected master branch

## Test plan
- [ ] Merge and verify release workflow succeeds
- [ ] Verify GitHub Release and CHANGELOG.md are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)