### PR TITLE
refactor(ci): simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,16 +42,17 @@ jobs:
           semantic-release version
           semantic-release publish
 
-      - name: Publish to PyPI
-        # Check if a new tag was created
-        if: success()
+      - name: Check for new release
+        id: check_release
         run: |
-           if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
-             echo "new_release=true" >> $GITHUB_ENV
-           fi
+          if git describe --exact-match --tags HEAD 2>/dev/null; then
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Build and Publish to PyPI
-        if: env.new_release == 'true'
+      - name: Publish to PyPI
+        if: steps.check_release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          skip_existing: true
+          skip-existing: true


### PR DESCRIPTION
## Summary
- Fix `skip_existing` → `skip-existing` deprecation warning
- Use step outputs instead of env vars for cleaner flow
- Simplify release detection logic

## Changes
- Consolidated PyPI publish condition check
- Cleaner step output handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)