### PR TITLE
fix(smithery): use uvx to run package from PyPI

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 # Smithery MCP Registry Configuration
-# https://smithery.ai
+# https://smithery.ai/docs/config#smitheryyaml
 
 startCommand:
   type: stdio
@@ -7,4 +7,4 @@ startCommand:
     type: object
     properties: {}
   commandFunction: |-
-    (config) => ({ command: 'pdf-modifier-mcp', args: [] })
+    (config) => ({ command: 'uvx', args: ['pdf-modifier-mcp'] })


### PR DESCRIPTION
## Summary
- Fix Smithery MCP deployment by using `uvx` to run the package
- `uvx` installs and runs the package on-the-fly from PyPI

## Problem
Smithery was failing with "Streamable HTTP error" because it tried to run `pdf-modifier-mcp` directly without having it installed.

## Solution
Use `uvx pdf-modifier-mcp` which:
1. Creates an isolated environment
2. Installs the package from PyPI
3. Runs the MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)