### PR TITLE
fix(ci): only publish to PyPI when dist artifacts exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,8 @@ jobs:
           semantic-release version
           semantic-release publish
 
-      - name: Check for new release
-        id: check_release
-        run: |
-          if git describe --exact-match --tags HEAD 2>/dev/null; then
-            echo "released=true" >> $GITHUB_OUTPUT
-          else
-            echo "released=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Publish to PyPI
-        if: steps.check_release.outputs.released == 'true'
+        if: hashFiles('dist/*.whl') != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true


### PR DESCRIPTION
## Summary
- Use `hashFiles('dist/*.whl')` to check if build artifacts exist before PyPI publish
- Prevents workflow failure when no new release is created (e.g., commits with no version bump)

## Problem
The release workflow failed with `FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/dist'` when there was no new version to release.

## Solution
Only run the PyPI publish step if `dist/*.whl` files exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)