### PR TITLE
feat(security): add password protection support and structured json logging

### DIFF
--- a/src/pdf_modifier_mcp/core/analyzer.py
+++ b/src/pdf_modifier_mcp/core/analyzer.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import fitz
 
-from .exceptions import PDFReadError
+from ..logger import setup_logging
+from .exceptions import PDFPasswordError, PDFReadError
 from .models import (
     FontInspectionResult,
     FontMatch,
@@ -16,7 +16,7 @@ from .models import (
     TextElement,
 )
 
-logger = logging.getLogger(__name__)
+logger = setup_logging(__name__)
 
 
 class PDFAnalyzer:
@@ -37,8 +37,24 @@ class PDFAnalyzer:
         >>> print(result.total_matches)
     """
 
-    def __init__(self, file_path: str | Path) -> None:
+    def __init__(self, file_path: str | Path, password: str | None = None) -> None:
         self.file_path = Path(file_path)
+        self.password = password
+
+    def _open_doc(self) -> fitz.Document:
+        """Safely open the document with password authentication if required."""
+        try:
+            doc = fitz.open(self.file_path)
+            if doc.needs_pass:
+                if not self.password:
+                    raise PDFPasswordError("PDF is password protected. Please provide a password.")
+                if not doc.authenticate(self.password):
+                    raise PDFPasswordError("Incorrect password provided for the PDF.")
+            return doc
+        except PDFPasswordError:
+            raise
+        except Exception as e:
+            raise PDFReadError(f"Failed to open PDF: {e}") from e
 
     def get_structure(self) -> PDFStructure:
         """
@@ -52,9 +68,10 @@ class PDFAnalyzer:
 
         Raises:
             PDFReadError: If the PDF cannot be read.
+            PDFPasswordError: If password is required but not provided or incorrect.
         """
         try:
-            with fitz.open(self.file_path) as doc:
+            with self._open_doc() as doc:
                 pages = []
                 for page_num, page in enumerate(doc, start=1):
                     elements = []
@@ -103,15 +120,18 @@ class PDFAnalyzer:
 
         Raises:
             PDFReadError: If the PDF cannot be read.
+            PDFPasswordError: If password is required but not provided or incorrect.
         """
         try:
-            with fitz.open(self.file_path) as doc:
+            with self._open_doc() as doc:
                 output = [f"Analyzed {self.file_path} with {len(doc)} pages.\n"]
                 for page_num, page in enumerate(doc, start=1):
                     output.append(f"--- Page {page_num} ---")
                     output.append(page.get_text("text"))
                     output.append("-" * 20)
                 return "\n".join(output)
+        except PDFPasswordError:
+            raise
         except Exception as e:
             raise PDFReadError(f"Failed to extract text: {e}") from e
 
@@ -129,11 +149,12 @@ class PDFAnalyzer:
 
         Raises:
             PDFReadError: If the PDF cannot be read.
+            PDFPasswordError: If password is required but not provided or incorrect.
         """
         matches: list[FontMatch] = []
 
         try:
-            with fitz.open(self.file_path) as doc:
+            with self._open_doc() as doc:
                 for page_num, page in enumerate(doc, start=1):
                     blocks = page.get_text("dict")["blocks"]
 

--- a/src/pdf_modifier_mcp/core/exceptions.py
+++ b/src/pdf_modifier_mcp/core/exceptions.py
@@ -43,6 +43,12 @@ class PDFWriteError(PDFModifierError):
     code = "WRITE_ERROR"
 
 
+class PDFPasswordError(PDFModifierError):
+    """Raised when a PDF requires a password but none (or an incorrect one) was provided."""
+
+    code = "PASSWORD_ERROR"
+
+
 class InvalidPatternError(PDFModifierError):
     """Regex pattern is invalid."""
 

--- a/src/pdf_modifier_mcp/core/modifier.py
+++ b/src/pdf_modifier_mcp/core/modifier.py
@@ -8,7 +8,7 @@ from typing import Any
 import fitz
 
 from ..logger import setup_logging
-from .exceptions import PDFReadError, PDFWriteError
+from .exceptions import PDFPasswordError, PDFReadError, PDFWriteError
 from .models import ModificationResult, ReplacementSpec
 
 logger = setup_logging(__name__)
@@ -35,9 +35,15 @@ class PDFModifier:
         ...     result = modifier.process(spec)
     """
 
-    def __init__(self, input_path: str | Path, output_path: str | Path) -> None:
+    def __init__(
+        self,
+        input_path: str | Path,
+        output_path: str | Path,
+        password: str | None = None,
+    ) -> None:
         self.input_path = Path(input_path).absolute()
         self.output_path = Path(output_path).absolute()
+        self.password = password
 
         if self.input_path == self.output_path:
             raise ValueError("Input and output paths cannot be the same. Risk of file corruption.")
@@ -45,11 +51,23 @@ class PDFModifier:
         self._doc: fitz.Document | None = None
         self._warnings: list[str] = []
 
-    def __enter__(self) -> PDFModifier:
+    def _open_doc(self) -> fitz.Document:
+        """Safely open the document with password authentication if required."""
         try:
-            self._doc = fitz.open(self.input_path)
+            doc = fitz.open(self.input_path)
+            if doc.needs_pass:
+                if not self.password:
+                    raise PDFPasswordError("PDF is password protected. Please provide a password.")
+                if not doc.authenticate(self.password):
+                    raise PDFPasswordError("Incorrect password provided for the PDF.")
+            return doc
+        except PDFPasswordError:
+            raise
         except Exception as e:
             raise PDFReadError(f"Cannot open PDF: {e}", {"path": str(self.input_path)}) from e
+
+    def __enter__(self) -> PDFModifier:
+        self._doc = self._open_doc()
         return self
 
     def __exit__(self, *args: Any) -> None:
@@ -79,11 +97,8 @@ class PDFModifier:
         """
         doc_opened_here = False
         if not self._doc:
-            try:
-                self._doc = fitz.open(self.input_path)
-                doc_opened_here = True
-            except Exception as e:
-                raise PDFReadError(f"Cannot open PDF: {e}") from e
+            self._doc = self._open_doc()
+            doc_opened_here = True
 
         total_replacements = 0
         pages_modified: set[int] = set()

--- a/src/pdf_modifier_mcp/interfaces/cli.py
+++ b/src/pdf_modifier_mcp/interfaces/cli.py
@@ -45,6 +45,10 @@ def modify(
         bool,
         typer.Option("--regex", help="Treat 'old' values as regex patterns"),
     ] = False,
+    password: Annotated[
+        str | None,
+        typer.Option("--password", "-p", help="Password if PDF is encrypted"),
+    ] = None,
 ) -> None:
     """
     Modify a PDF by finding and replacing text while preserving font style.
@@ -68,7 +72,11 @@ def modify(
 
     try:
         spec = ReplacementSpec(replacements=replacements, use_regex=regex)
-        modifier = PDFModifier(str(input_pdf.absolute()), str(output_pdf.absolute()))
+        modifier = PDFModifier(
+            str(input_pdf.absolute()),
+            str(output_pdf.absolute()),
+            password=password,
+        )
 
         with console.status("[bold green]Modifying PDF...", spinner="dots"):
             result = modifier.process(spec)
@@ -98,6 +106,10 @@ def analyze(
         bool,
         typer.Option("--json", "-j", help="Output as JSON structure"),
     ] = False,
+    password: Annotated[
+        str | None,
+        typer.Option("--password", "-p", help="Password if PDF is encrypted"),
+    ] = None,
 ) -> None:
     """
     Extract text or structure from a PDF.
@@ -105,7 +117,7 @@ def analyze(
     Use --json for machine-readable output with positions and fonts.
     """
     try:
-        analyzer = PDFAnalyzer(str(input_pdf.absolute()))
+        analyzer = PDFAnalyzer(str(input_pdf.absolute()), password=password)
 
         if json_output:
             result = analyzer.get_structure()
@@ -122,6 +134,10 @@ def analyze(
 def inspect(
     input_pdf: Annotated[Path, typer.Argument(help="Path to input PDF")],
     terms: Annotated[list[str], typer.Argument(help="Terms to search for")],
+    password: Annotated[
+        str | None,
+        typer.Option("--password", "-p", help="Password if PDF is encrypted"),
+    ] = None,
 ) -> None:
     """
     Inspect font properties for specific terms in a PDF.
@@ -129,7 +145,7 @@ def inspect(
     Useful for understanding font styles before making replacements.
     """
     try:
-        analyzer = PDFAnalyzer(str(input_pdf.absolute()))
+        analyzer = PDFAnalyzer(str(input_pdf.absolute()), password=password)
         result = analyzer.inspect_fonts(terms)
 
         if not result.matches:

--- a/src/pdf_modifier_mcp/interfaces/mcp.py
+++ b/src/pdf_modifier_mcp/interfaces/mcp.py
@@ -52,7 +52,7 @@ def handle_mcp_errors(func: Callable[..., str]) -> Callable[..., str]:
 
 @mcp.tool()
 @handle_mcp_errors
-def read_pdf_structure(input_path: str) -> str:
+def read_pdf_structure(input_path: str, password: str | None = None) -> str:
     """
     Extract the complete structural content of a PDF document.
 
@@ -72,6 +72,7 @@ def read_pdf_structure(input_path: str) -> str:
     Args:
         input_path: Absolute path to the PDF file to analyze.
                    Must be a valid, accessible PDF file.
+        password: Optional password if the PDF is encrypted.
 
     Returns:
         JSON string containing the complete page structure.
@@ -80,14 +81,14 @@ def read_pdf_structure(input_path: str) -> str:
     Example:
         read_pdf_structure("/home/user/documents/invoice.pdf")
     """
-    analyzer = PDFAnalyzer(input_path)
+    analyzer = PDFAnalyzer(input_path, password=password)
     result = analyzer.get_structure()
     return result.model_dump_json(indent=2)
 
 
 @mcp.tool()
 @handle_mcp_errors
-def inspect_pdf_fonts(input_path: str, terms: list[str]) -> str:
+def inspect_pdf_fonts(input_path: str, terms: list[str], password: str | None = None) -> str:
     """
     Search for specific text terms and report their font properties.
 
@@ -107,6 +108,7 @@ def inspect_pdf_fonts(input_path: str, terms: list[str]) -> str:
         input_path: Absolute path to the PDF file to inspect.
         terms: List of text strings to search for (1-50 terms).
                Each term is searched as a substring.
+        password: Optional password if the PDF is encrypted.
 
     Returns:
         JSON string with all matches and their font properties.
@@ -115,7 +117,7 @@ def inspect_pdf_fonts(input_path: str, terms: list[str]) -> str:
     Example:
         inspect_pdf_fonts("/path/to/doc.pdf", ["Invoice", "$99.99", "Total"])
     """
-    analyzer = PDFAnalyzer(input_path)
+    analyzer = PDFAnalyzer(input_path, password=password)
     result = analyzer.inspect_fonts(terms)
     return result.model_dump_json(indent=2)
 
@@ -127,6 +129,7 @@ def modify_pdf_content(
     output_path: str,
     replacements: dict[str, str],
     use_regex: bool = False,
+    password: str | None = None,
 ) -> str:
     """
     Find and replace text in a PDF while preserving font styles.
@@ -160,6 +163,7 @@ def modify_pdf_content(
                      Values are replacement strings (optionally with |URL).
         use_regex: If true, treat replacement keys as regex patterns.
                   Default is false for literal string matching.
+        password: Optional password if the source PDF is encrypted.
 
     Returns:
         JSON string with modification results including:
@@ -192,7 +196,7 @@ def modify_pdf_content(
         )
     """
     spec = ReplacementSpec(replacements=replacements, use_regex=use_regex)
-    modifier = PDFModifier(input_path, output_path)
+    modifier = PDFModifier(input_path, output_path, password=password)
     result = modifier.process(spec)
     return result.model_dump_json(indent=2)
 

--- a/src/pdf_modifier_mcp/logger.py
+++ b/src/pdf_modifier_mcp/logger.py
@@ -1,6 +1,21 @@
+import json
 import logging
+from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_data = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+        return json.dumps(log_data)
 
 
 def setup_logging(name: str) -> logging.Logger:
@@ -12,8 +27,7 @@ def setup_logging(name: str) -> logging.Logger:
     if not logger.handlers:
         logger.setLevel(logging.INFO)
         handler = RotatingFileHandler(log_file, maxBytes=5 * 1024 * 1024, backupCount=3)
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        handler.setFormatter(formatter)
+        handler.setFormatter(JsonFormatter())
         logger.addHandler(handler)
 
     return logger


### PR DESCRIPTION
Closes #13
Closes #17

### Changes
- Add password authentication to `PDFAnalyzer` and `PDFModifier` using PyMuPDF native support.
- Expose `password` parameter in CLI (`--password`) and all MCP tools.
- Refactor internal logger to emit machine-readable JSON logs for silent failures, improving observability in MCP clients.
- Handle `PDFPasswordError` explicitly to provide clear actionable feedback to users/agents.

### Testing
- [x] `make check` passes
- [x] Manual testing completed

### Type
- [x] Bug fix
- [x] New feature