### PR TITLE
fix(ci): improve new release detection logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,17 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          semantic-release version
-          semantic-release publish
-          # Check if a new tag was created in this run
-          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
-            echo "new_release=true" >> $GITHUB_OUTPUT
-          else
+
+          # Run version command and capture output
+          OUTPUT=$(semantic-release version 2>&1)
+          echo "$OUTPUT"
+
+          if echo "$OUTPUT" | grep -q "No release will be made"; then
             echo "new_release=false" >> $GITHUB_OUTPUT
+          else
+            # Proceed with publish
+            semantic-release publish
+            echo "new_release=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish to PyPI


### PR DESCRIPTION
Fixes the issue where `publish-mcp` job was running even when no new version was released, causing 'duplicate version' errors in the MCP Registry.

### Changes
- Use `semantic-release version` output to accurately detect if a release was performed.
- Only set `new_release=true` if PSR didn't skip the release.
- Strictly follows branch + PR workflow.