### PR TITLE
fix(ci): revert to RELEASE_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Semantic Release
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Reverts the token used by `semantic-release` back to `RELEASE_TOKEN`.

### Context
- `GITHUB_TOKEN` is subject to branch protection rules (PR required, status checks).
- `semantic-release` needs to push directly to `master` to update metadata.
- `RELEASE_TOKEN` is a pre-configured secret (likely a PAT) that has the necessary bypass permissions.
- strictly follows branch + PR workflow.