### PR TITLE
feat(analyzer): add hyperlink inventory support

### DIFF
--- a/site/src/content/docs/getting-started.md
+++ b/site/src/content/docs/getting-started.md
@@ -96,6 +96,16 @@ pdf-mod inspect input.pdf "Invoice" "Total" "$"
 
 Output columns: Page, Term, Font, Size, Context (first 100 characters of the containing span).
 
+### List hyperlinks
+
+Inventory all existing links in the document:
+
+```bash
+pdf-mod links input.pdf
+```
+
+Output includes page number, target URI, and the text area covered by the link.
+
 ## MCP Server
 
 The MCP server exposes the same functionality over stdio for AI agent integration. **Use user scope (`-s user`) so the tools are available across all your projects.**
@@ -147,9 +157,10 @@ Any MCP-compatible client (like Cursor or Windsurf) that supports stdio transpor
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `read_pdf_structure` | `input_path` | Returns complete PDF structure — text, bounding boxes, font names, sizes, colors — as JSON. Use this first to understand the document layout before making changes. |
-| `inspect_pdf_fonts` | `input_path`, `terms[]` | Searches for text terms (substring match) and returns font name, size, and position for each match. Run this before replacements to verify font handling. |
-| `modify_pdf_content` | `input_path`, `output_path`, `replacements{}`, `use_regex?` | Find and replace text with style preservation. Supports regex patterns and hyperlink syntax (`text\|URL`). Returns replacements made, pages modified, and any warnings. |
+| `read_pdf_structure` | `input_path`, `password?` | Returns complete PDF structure — text, bounding boxes, font names, sizes, colors — as JSON. Use this first to understand the document layout before making changes. |
+| `inspect_pdf_fonts` | `input_path`, `terms[]`, `password?` | Searches for text terms (substring match) and returns font name, size, and position for each match. Run this before replacements to verify font handling. |
+| `list_pdf_hyperlinks` | `input_path`, `password?` | Extracts all existing hyperlinks and URIs from the document, including their location and covered text. |
+| `modify_pdf_content` | `input_path`, `output_path`, `replacements{}`, `use_regex?`, `password?` | Find and replace text with style preservation. Supports regex patterns and hyperlink syntax (`text\|URL`). Returns replacements made, pages modified, and any warnings. |
 
 All tools return structured JSON. Errors include a typed error code (`FILE_NOT_FOUND`, `READ_ERROR`, `WRITE_ERROR`), a human-readable message, and a details object.
 

--- a/src/pdf_modifier_mcp/core/analyzer.py
+++ b/src/pdf_modifier_mcp/core/analyzer.py
@@ -11,6 +11,8 @@ from .exceptions import PDFPasswordError, PDFReadError
 from .models import (
     FontInspectionResult,
     FontMatch,
+    Hyperlink,
+    HyperlinkInventory,
     PageStructure,
     PDFStructure,
     TextElement,
@@ -186,3 +188,41 @@ class PDFAnalyzer:
 
         except Exception as e:
             raise PDFReadError(f"Failed to inspect fonts: {e}") from e
+
+    def get_hyperlinks(self) -> HyperlinkInventory:
+        """
+        Extract all hyperlinks from the document.
+
+        Returns:
+            HyperlinkInventory containing all found URIs and their locations.
+
+        Raises:
+            PDFReadError: If the PDF cannot be read.
+            PDFPasswordError: If password is required but not provided or incorrect.
+        """
+        links: list[Hyperlink] = []
+
+        try:
+            with self._open_doc() as doc:
+                for page_num, page in enumerate(doc, start=1):
+                    for link in page.get_links():
+                        if "uri" in link:
+                            # Try to find text under the link's bbox
+                            text = page.get_textbox(link["from"])
+                            links.append(
+                                Hyperlink(
+                                    page=page_num,
+                                    uri=link["uri"],
+                                    bbox=tuple(link["from"]),  # type: ignore[arg-type]
+                                    text=text.strip() if text else None,
+                                )
+                            )
+
+            return HyperlinkInventory(
+                file_path=str(self.file_path),
+                total_links=len(links),
+                links=links,
+            )
+
+        except Exception as e:
+            raise PDFReadError(f"Failed to extract hyperlinks: {e}") from e

--- a/src/pdf_modifier_mcp/core/models.py
+++ b/src/pdf_modifier_mcp/core/models.py
@@ -89,6 +89,24 @@ class FontInspectionResult(BaseModel):
     total_matches: int
 
 
+class Hyperlink(BaseModel):
+    """Details of a hyperlink found in a PDF."""
+
+    page: int
+    uri: str
+    bbox: tuple[float, float, float, float]
+    text: str | None = Field(None, description="Text covered by the link area (if available)")
+
+
+class HyperlinkInventory(BaseModel):
+    """Complete inventory of hyperlinks in a PDF."""
+
+    success: bool = True
+    file_path: str
+    total_links: int
+    links: list[Hyperlink]
+
+
 class ModificationResult(BaseModel):
     """Result of PDF modification operation."""
 

--- a/src/pdf_modifier_mcp/interfaces/cli.py
+++ b/src/pdf_modifier_mcp/interfaces/cli.py
@@ -176,6 +176,47 @@ def inspect(
         raise typer.Exit(code=1) from None
 
 
+@app.command()
+def links(
+    input_pdf: Annotated[Path, typer.Argument(help="Path to input PDF")],
+    password: Annotated[
+        str | None,
+        typer.Option("--password", "-p", help="Password if PDF is encrypted"),
+    ] = None,
+) -> None:
+    """
+    List all hyperlinks found in a PDF document.
+    """
+    try:
+        analyzer = PDFAnalyzer(str(input_pdf.absolute()), password=password)
+        result = analyzer.get_hyperlinks()
+
+        if not result.links:
+            console.print("[yellow]No hyperlinks found.[/]")
+            return
+
+        table = Table(title=f"Hyperlink Inventory: {input_pdf.name}")
+        table.add_column("Page", style="cyan")
+        table.add_column("URI", style="green")
+        table.add_column("Text Area", style="magenta")
+
+        for link in result.links:
+            text_raw = link.text or "-"
+            text = text_raw[:50] + "..." if len(text_raw) > 50 else text_raw
+            table.add_row(
+                str(link.page),
+                link.uri,
+                text,
+            )
+
+        console.print(table)
+        console.print(f"\n[bold]Total links found:[/] {result.total_links}")
+
+    except PDFModifierError as e:
+        console.print(f"[red]Error:[/] {e.message}")
+        raise typer.Exit(code=1) from None
+
+
 def main() -> None:
     """Entry point for CLI."""
     app()

--- a/src/pdf_modifier_mcp/interfaces/mcp.py
+++ b/src/pdf_modifier_mcp/interfaces/mcp.py
@@ -201,6 +201,31 @@ def modify_pdf_content(
     return result.model_dump_json(indent=2)
 
 
+@mcp.tool()
+@handle_mcp_errors
+def list_pdf_hyperlinks(input_path: str, password: str | None = None) -> str:
+    """
+    Extract all existing hyperlinks and clickable URIs from a PDF.
+
+    Use this tool to inventory the links in a document before or after
+    making modifications. It reports the target URI, its location (bbox),
+    and the text covered by the link if detectable.
+
+    Args:
+        input_path: Absolute path to the PDF file to scan.
+        password: Optional password if the PDF is encrypted.
+
+    Returns:
+        JSON string with the inventory of found hyperlinks.
+
+    Example:
+        list_pdf_hyperlinks("/path/to/report.pdf")
+    """
+    analyzer = PDFAnalyzer(input_path, password=password)
+    result = analyzer.get_hyperlinks()
+    return result.model_dump_json(indent=2)
+
+
 def main() -> None:
     """Run the MCP server with stdio transport."""
     mcp.run()

--- a/tests/unit/core/test_hyperlinks.py
+++ b/tests/unit/core/test_hyperlinks.py
@@ -1,0 +1,49 @@
+"""Tests for hyperlink extraction."""
+
+from pathlib import Path
+
+import fitz
+
+from pdf_modifier_mcp.core import PDFAnalyzer
+from pdf_modifier_mcp.core.models import HyperlinkInventory
+
+
+def test_get_hyperlinks(tmp_path: Path) -> None:
+    # Create a PDF with a link
+    pdf_path = tmp_path / "test_links.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((100, 100), "Google")
+
+    # Add a link over the text area
+    link_rect = fitz.Rect(95, 90, 150, 110)
+    page.insert_link({"from": link_rect, "uri": "https://google.com", "kind": fitz.LINK_URI})
+
+    doc.save(str(pdf_path))
+    doc.close()
+
+    # Analyze it
+    analyzer = PDFAnalyzer(pdf_path)
+    inventory = analyzer.get_hyperlinks()
+
+    assert isinstance(inventory, HyperlinkInventory)
+    assert inventory.total_links == 1
+    assert inventory.links[0].uri == "https://google.com"
+    assert inventory.links[0].text is not None
+    assert "Google" in inventory.links[0].text
+    assert inventory.links[0].page == 1
+
+
+def test_get_hyperlinks_no_links(tmp_path: Path) -> None:
+    # Create a PDF without links
+    pdf_path = tmp_path / "no_links.pdf"
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(str(pdf_path))
+    doc.close()
+
+    analyzer = PDFAnalyzer(pdf_path)
+    inventory = analyzer.get_hyperlinks()
+
+    assert inventory.total_links == 0
+    assert len(inventory.links) == 0


### PR DESCRIPTION
Closes #8

### Changes
- Implemented `get_hyperlinks` in `PDFAnalyzer` using PyMuPDF's `get_links()`.
- Added a new MCP tool `list_pdf_hyperlinks` for agent-based link auditing.
- Added a `links` command to the CLI with a formatted Rich table.
- Extended the documentation site with instructions for the new tool.
- Full test coverage for the new core logic.

### Testing
- [x] `make check` passes
- [x] New unit tests added in `tests/unit/core/test_hyperlinks.py`
- [x] Manual verification of CLI output