### PR TITLE
fix(ci): release without branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # 1. Bump version locally
+          # 1. Bump version and create tag locally
           semantic-release version
 
-          # 2. Check if a new tag was created on current HEAD
+          # 2. Check if a new tag was created on current commit
           NEW_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "none")
 
           if [ "$NEW_TAG" != "none" ]; then
@@ -53,7 +53,8 @@ jobs:
             echo "new_release=true" >> $GITHUB_OUTPUT
             echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
-            # 3. Publish to VCS (push tags and metadata commits)
+            # 3. Publish (this will push the TAG to VCS and release artifacts)
+            # Since we set commit=false in pyproject.toml, this won't push branch commits
             semantic-release publish
           else
             echo "No new release created"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ select = ["E", "F", "I", "N", "UP", "B", "C4", "SIM"]
 known-first-party = ["pdf_modifier_mcp"]
 
 [tool.semantic_release]
+commit = false
 version_toml = ["pyproject.toml:project.version"]
 version_variables = [
     "server.json:version"


### PR DESCRIPTION
Solves the recurring release failure by disabling direct pushes to the protected `master` branch.

### Changes
- Configured `python-semantic-release` with `commit = false` in `pyproject.toml`.
- This ensures PSR only creates and pushes the **Version Tag** and artifacts (PyPI, GitHub Release).
- The version in the repository code will remain unchanged, but the published artifacts will have the correct incremented version.
- This is the recommended approach for branches with strict status checks and PR requirements.