### PR TITLE
fix(ci): correct YAML syntax error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
           else
             echo "No new release created"
             echo "new_release=false" >> $GITHUB_OUTPUT
-          fi      - name: Publish to PyPI
+          fi
+
+      - name: Publish to PyPI
         if: hashFiles('dist/*.whl') != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Fixes a syntax error in the release workflow where a newline was missing between the end of a shell script and the next job step.

### Changes
- Added missing newline after `fi`.
- strictly follows branch + PR workflow.