### PR TITLE
feat(mcp): add batch processing support

### DIFF
--- a/src/pdf_modifier_mcp/core/__init__.py
+++ b/src/pdf_modifier_mcp/core/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     PDFWriteError,
 )
 from .models import (
+    BatchResult,
     FontInspectionResult,
     FontMatch,
     ModificationResult,
@@ -21,13 +22,16 @@ from .models import (
     ReplacementSpec,
     TextElement,
 )
-from .modifier import PDFModifier
+from .modifier import PDFModifier, batch_process
 
 __all__ = [
     # Classes
     "PDFAnalyzer",
     "PDFModifier",
+    # Functions
+    "batch_process",
     # Models
+    "BatchResult",
     "FontInspectionResult",
     "FontMatch",
     "ModificationResult",

--- a/src/pdf_modifier_mcp/core/models.py
+++ b/src/pdf_modifier_mcp/core/models.py
@@ -116,3 +116,13 @@ class ModificationResult(BaseModel):
     replacements_made: int
     pages_modified: int
     warnings: list[str] = Field(default_factory=list)
+
+
+class BatchResult(BaseModel):
+    """Result of batch PDF modification."""
+
+    total_files: int
+    successful: int
+    failed: int
+    results: list[ModificationResult]
+    errors: list[dict[str, str]] = Field(default_factory=list)

--- a/src/pdf_modifier_mcp/core/modifier.py
+++ b/src/pdf_modifier_mcp/core/modifier.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 import fitz
 
@@ -16,7 +19,7 @@ from .exceptions import (
     PDFReadError,
     PDFWriteError,
 )
-from .models import ModificationResult, ReplacementSpec
+from .models import BatchResult, ModificationResult, ReplacementSpec
 
 logger = setup_logging(__name__)
 
@@ -326,3 +329,61 @@ class PDFModifier:
                 msg = f"Could not add link for '{item['text']}': {e}"
                 logger.warning(msg)
                 self._warnings.append(msg)
+
+
+def batch_process(
+    file_paths: Sequence[str | Path],
+    output_dir: str | Path,
+    spec: ReplacementSpec,
+    password: str | None = None,
+) -> BatchResult:
+    """
+    Apply the same replacements to multiple PDF files.
+
+    Each file is processed independently; failures in one file do not
+    affect the rest of the batch. Output files are written to
+    ``output_dir`` using the same filename as the input.
+
+    Args:
+        file_paths: List of input PDF file paths.
+        output_dir: Directory where modified PDFs will be saved.
+        spec: ReplacementSpec containing replacements and options.
+        password: Optional password for encrypted PDFs.
+
+    Returns:
+        BatchResult with per-file results and aggregate statistics.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[ModificationResult] = []
+    errors: list[dict[str, str]] = []
+
+    for file_path in file_paths:
+        file_path = Path(file_path)
+        output_path = output_dir / file_path.name
+
+        if file_path.absolute() == output_path.absolute():
+            errors.append(
+                {
+                    "file": str(file_path),
+                    "error": "Input and output paths are the same",
+                }
+            )
+            continue
+
+        try:
+            modifier = PDFModifier(str(file_path), str(output_path), password=password)
+            result = modifier.process(spec)
+            results.append(result)
+        except Exception as e:
+            logger.warning("Batch: failed to process %s: %s", file_path, e)
+            errors.append({"file": str(file_path), "error": str(e)})
+
+    return BatchResult(
+        total_files=len(file_paths),
+        successful=len(results),
+        failed=len(errors),
+        results=results,
+        errors=errors,
+    )

--- a/src/pdf_modifier_mcp/interfaces/cli.py
+++ b/src/pdf_modifier_mcp/interfaces/cli.py
@@ -16,7 +16,7 @@ from rich.table import Table
 from ..core.analyzer import PDFAnalyzer
 from ..core.exceptions import PDFModifierError
 from ..core.models import ReplacementSpec
-from ..core.modifier import PDFModifier
+from ..core.modifier import PDFModifier, batch_process
 from ..logger import setup_logging
 
 logger = setup_logging(__name__)
@@ -95,6 +95,94 @@ def modify(
         raise typer.Exit(code=1) from None
     except Exception:
         logger.exception("Unexpected error in CLI modify")
+        console.print("[red]Error:[/] An unexpected error occurred. Check logs.")
+        raise typer.Exit(code=1) from None
+
+
+@app.command()
+def batch(
+    input_pdfs: Annotated[
+        list[Path],
+        typer.Argument(help="Paths to input PDF files"),
+    ],
+    output_dir: Annotated[
+        Path,
+        typer.Option("--output-dir", "-o", help="Directory for modified PDFs"),
+    ],
+    replace: Annotated[
+        list[str],
+        typer.Option(
+            "--replace",
+            "-r",
+            help="Format: 'old=new'. Use '|url' suffix for links.",
+        ),
+    ],
+    regex: Annotated[
+        bool,
+        typer.Option("--regex", help="Treat 'old' values as regex"),
+    ] = False,
+    password: Annotated[
+        str | None,
+        typer.Option("--password", "-p", help="Password if PDFs are encrypted"),
+    ] = None,
+) -> None:
+    """
+    Apply the same replacements to multiple PDF files.
+
+    Processes each file independently. Failed files do not stop the batch.
+    Output files are saved to --output-dir with the same filename.
+
+    Examples:
+        pdf-mod batch a.pdf b.pdf -o out/ -r "Draft=Final"
+        pdf-mod batch *.pdf -o out/ -r "2024=2025" -r "old=new"
+    """
+    replacements: dict[str, str] = {}
+    for item in replace:
+        if "=" not in item:
+            console.print(
+                f"[yellow]Warning:[/] Skipping invalid format" f" '{item}'. Use 'old=new'."
+            )
+            continue
+        old, new = item.split("=", 1)
+        replacements[old] = new
+
+    if not replacements:
+        console.print("[red]Error:[/] No valid replacements provided.")
+        raise typer.Exit(code=1)
+
+    try:
+        spec = ReplacementSpec(replacements=replacements, use_regex=regex)
+
+        with console.status("[bold green]Processing batch...", spinner="dots"):
+            result = batch_process(input_pdfs, output_dir, spec, password=password)
+
+        table = Table(title="Batch Results")
+        table.add_column("File", style="cyan")
+        table.add_column("Status", style="green")
+        table.add_column("Replacements")
+
+        for res in result.results:
+            table.add_row(
+                res.input_path,
+                "OK",
+                str(res.replacements_made),
+            )
+        for err in result.errors:
+            table.add_row(err["file"], f"[red]{err['error']}[/]", "-")
+
+        console.print(table)
+        console.print(
+            f"\n[bold]{result.successful} succeeded[/],"
+            f" [bold]{result.failed} failed[/]"
+            f" out of {result.total_files} files."
+        )
+
+    except PDFModifierError as e:
+        logger.error("Batch error: %s", e.message)
+        console.print(f"[red]Error:[/] {e.message}")
+        raise typer.Exit(code=1) from None
+    except Exception:
+        logger.exception("Unexpected error in CLI batch")
         console.print("[red]Error:[/] An unexpected error occurred. Check logs.")
         raise typer.Exit(code=1) from None
 

--- a/src/pdf_modifier_mcp/interfaces/mcp.py
+++ b/src/pdf_modifier_mcp/interfaces/mcp.py
@@ -17,7 +17,7 @@ from fastmcp import FastMCP
 from ..core.analyzer import PDFAnalyzer
 from ..core.exceptions import PDFModifierError
 from ..core.models import ReplacementSpec
-from ..core.modifier import PDFModifier
+from ..core.modifier import PDFModifier, batch_process
 from ..logger import setup_logging
 
 logger = setup_logging(__name__)
@@ -223,6 +223,44 @@ def list_pdf_hyperlinks(input_path: str, password: str | None = None) -> str:
     """
     analyzer = PDFAnalyzer(input_path, password=password)
     result = analyzer.get_hyperlinks()
+    return result.model_dump_json(indent=2)
+
+
+@mcp.tool()
+@handle_mcp_errors
+def batch_modify_pdf_content(
+    input_paths: list[str],
+    output_dir: str,
+    replacements: dict[str, str],
+    use_regex: bool = False,
+    password: str | None = None,
+) -> str:
+    """
+    Apply the same text replacements to multiple PDF files at once.
+
+    Each file is processed independently -- a failure in one file does
+    not stop the rest of the batch. Output files are written to
+    ``output_dir`` using the same filename as the input.
+
+    Args:
+        input_paths: List of absolute paths to input PDF files.
+        output_dir: Directory where modified PDFs will be saved.
+        replacements: Dictionary mapping old text to new text.
+        use_regex: If true, treat keys as regex patterns.
+        password: Optional password if PDFs are encrypted.
+
+    Returns:
+        JSON string with batch results including per-file status.
+
+    Example:
+        batch_modify_pdf_content(
+            ["/path/a.pdf", "/path/b.pdf"],
+            "/path/output",
+            {"Draft": "Final", "2024": "2025"}
+        )
+    """
+    spec = ReplacementSpec(replacements=replacements, use_regex=use_regex)
+    result = batch_process(input_paths, output_dir, spec, password=password)
     return result.model_dump_json(indent=2)
 
 

--- a/tests/unit/core/test_batch.py
+++ b/tests/unit/core/test_batch.py
@@ -1,0 +1,119 @@
+"""Tests for batch_process function."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pdf_modifier_mcp.core.models import ReplacementSpec
+from pdf_modifier_mcp.core.modifier import batch_process
+
+from ...conftest import create_pdf
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestBatchProcessMultipleFiles:
+    """Tests for processing multiple files in a batch."""
+
+    def test_batch_processes_multiple_files(self, tmp_path: Path) -> None:
+        """All valid files are processed and results aggregated."""
+        pdf1 = create_pdf(tmp_path / "file1.pdf", text="Hello World")
+        pdf2 = create_pdf(tmp_path / "file2.pdf", text="Hello World")
+        output_dir = tmp_path / "output"
+
+        spec = ReplacementSpec(replacements={"Hello": "Goodbye"})
+        result = batch_process([str(pdf1), str(pdf2)], str(output_dir), spec)
+
+        assert result.total_files == 2
+        assert result.successful == 2
+        assert result.failed == 0
+        assert len(result.results) == 2
+        assert len(result.errors) == 0
+        assert (output_dir / "file1.pdf").exists()
+        assert (output_dir / "file2.pdf").exists()
+
+    def test_batch_skips_failed_files(self, tmp_path: Path) -> None:
+        """Corrupt or missing files are skipped without failing the batch."""
+        pdf_good = create_pdf(tmp_path / "good.pdf", text="Hello World")
+        pdf_missing = tmp_path / "missing.pdf"
+        output_dir = tmp_path / "output"
+
+        spec = ReplacementSpec(replacements={"Hello": "Goodbye"})
+        result = batch_process([str(pdf_good), str(pdf_missing)], str(output_dir), spec)
+
+        assert result.total_files == 2
+        assert result.successful == 1
+        assert result.failed == 1
+        assert len(result.results) == 1
+        assert len(result.errors) == 1
+        assert result.errors[0]["file"] == str(pdf_missing)
+
+    def test_batch_output_dir_structure(self, tmp_path: Path) -> None:
+        """Output files are placed in output_dir with original filenames."""
+        subdir = tmp_path / "inputs"
+        subdir.mkdir()
+        pdf1 = create_pdf(subdir / "report.pdf", text="Draft Version")
+        output_dir = tmp_path / "results"
+
+        spec = ReplacementSpec(replacements={"Draft": "Final"})
+        result = batch_process([str(pdf1)], str(output_dir), spec)
+
+        assert result.successful == 1
+        output_file = output_dir / "report.pdf"
+        assert output_file.exists()
+        assert result.results[0].output_path == str(output_file)
+
+    def test_batch_empty_list(self, tmp_path: Path) -> None:
+        """Empty input list returns zero counts and no errors."""
+        output_dir = tmp_path / "output"
+        spec = ReplacementSpec(replacements={"a": "b"})
+        result = batch_process([], str(output_dir), spec)
+
+        assert result.total_files == 0
+        assert result.successful == 0
+        assert result.failed == 0
+        assert len(result.results) == 0
+        assert len(result.errors) == 0
+
+    def test_batch_with_regex(self, tmp_path: Path) -> None:
+        """Regex replacements work across batch files."""
+        pdf1 = create_pdf(tmp_path / "file1.pdf", text="Date: 2024-01-15")
+        pdf2 = create_pdf(tmp_path / "file2.pdf", text="Date: 2024-06-30")
+        output_dir = tmp_path / "output"
+
+        spec = ReplacementSpec(
+            replacements={r"\d{4}-\d{2}-\d{2}": "REDACTED"},
+            use_regex=True,
+        )
+        result = batch_process([str(pdf1), str(pdf2)], str(output_dir), spec)
+
+        assert result.total_files == 2
+        assert result.successful == 2
+        assert result.failed == 0
+        for res in result.results:
+            assert res.replacements_made >= 1
+
+    def test_batch_creates_output_dir(self, tmp_path: Path) -> None:
+        """Output directory is created automatically if it does not exist."""
+        pdf = create_pdf(tmp_path / "test.pdf", text="Hello")
+        output_dir = tmp_path / "nested" / "deep" / "output"
+
+        spec = ReplacementSpec(replacements={"Hello": "Goodbye"})
+        result = batch_process([str(pdf)], str(output_dir), spec)
+
+        assert result.successful == 1
+        assert output_dir.exists()
+
+    def test_batch_skips_same_input_output(self, tmp_path: Path) -> None:
+        """Files where input == output are reported as errors."""
+        output_dir = tmp_path  # Same directory as the input files
+        pdf = create_pdf(tmp_path / "conflict.pdf", text="Hello")
+
+        spec = ReplacementSpec(replacements={"Hello": "Goodbye"})
+        result = batch_process([str(pdf)], str(output_dir), spec)
+
+        assert result.total_files == 1
+        assert result.successful == 0
+        assert result.failed == 1
+        assert "same" in result.errors[0]["error"].lower()

--- a/tests/unit/interfaces/test_cli.py
+++ b/tests/unit/interfaces/test_cli.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from pdf_modifier_mcp.interfaces.cli import app
 
-from ...conftest import SAMPLE_PDF
+from ...conftest import SAMPLE_PDF, create_pdf
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -138,6 +138,66 @@ class TestCLILinks:
         assert "https://example.com" in result.stdout
 
 
+class TestCLIBatch:
+    """Tests for CLI batch command."""
+
+    def test_batch_multiple_files(self, tmp_path: Path) -> None:
+        pdf1 = create_pdf(tmp_path / "a.pdf", text="Hello World")
+        pdf2 = create_pdf(tmp_path / "b.pdf", text="Hello World")
+        output_dir = tmp_path / "out"
+
+        result = runner.invoke(
+            app,
+            [
+                "batch",
+                str(pdf1),
+                str(pdf2),
+                "-o",
+                str(output_dir),
+                "-r",
+                "Hello=Goodbye",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "2 succeeded" in result.stdout
+        assert (output_dir / "a.pdf").exists()
+        assert (output_dir / "b.pdf").exists()
+
+    def test_batch_with_failed_file(self, tmp_path: Path) -> None:
+        pdf_good = create_pdf(tmp_path / "good.pdf", text="Hello")
+        output_dir = tmp_path / "out"
+
+        result = runner.invoke(
+            app,
+            [
+                "batch",
+                str(pdf_good),
+                str(tmp_path / "missing.pdf"),
+                "-o",
+                str(output_dir),
+                "-r",
+                "Hello=Goodbye",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "1 succeeded" in result.stdout
+        assert "1 failed" in result.stdout
+
+    def test_batch_invalid_format_error(self, tmp_path: Path) -> None:
+        pdf = create_pdf(tmp_path / "test.pdf", text="Hello")
+        output_dir = tmp_path / "out"
+
+        result = runner.invoke(
+            app,
+            ["batch", str(pdf), "-o", str(output_dir), "-r", "no_equals"],
+        )
+        assert result.exit_code == 1
+
+    def test_batch_shows_in_help(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert "batch" in result.stdout
+
+
 class TestCLIHelp:
     """Tests for CLI help."""
 
@@ -145,6 +205,7 @@ class TestCLIHelp:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
         assert "modify" in result.stdout
+        assert "batch" in result.stdout
         assert "analyze" in result.stdout
         assert "inspect" in result.stdout
         assert "links" in result.stdout

--- a/tests/unit/interfaces/test_mcp.py
+++ b/tests/unit/interfaces/test_mcp.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import fitz
 
 from pdf_modifier_mcp.interfaces.mcp import (
+    batch_modify_pdf_content,
     inspect_pdf_fonts,
     list_pdf_hyperlinks,
     mcp,
@@ -155,6 +156,61 @@ class TestMCPListHyperlinks:
         result = list_pdf_hyperlinks(str(tmp_path / "missing.pdf"))
         parsed = json.loads(result)
         assert parsed["success"] is False
+
+
+class TestMCPBatchModify:
+    """Tests for batch_modify_pdf_content tool."""
+
+    def test_batch_multiple_files(self, tmp_path: Path) -> None:
+        pdf1 = create_pdf(tmp_path / "a.pdf", text="Hello World")
+        pdf2 = create_pdf(tmp_path / "b.pdf", text="Hello World")
+        output_dir = tmp_path / "out"
+
+        result = batch_modify_pdf_content(
+            [str(pdf1), str(pdf2)],
+            str(output_dir),
+            {"Hello": "Goodbye"},
+        )
+        parsed = json.loads(result)
+        assert parsed["total_files"] == 2
+        assert parsed["successful"] == 2
+        assert parsed["failed"] == 0
+
+    def test_batch_with_missing_file(self, tmp_path: Path) -> None:
+        pdf_good = create_pdf(tmp_path / "good.pdf", text="Hello")
+        output_dir = tmp_path / "out"
+
+        result = batch_modify_pdf_content(
+            [str(pdf_good), str(tmp_path / "missing.pdf")],
+            str(output_dir),
+            {"Hello": "Goodbye"},
+        )
+        parsed = json.loads(result)
+        assert parsed["total_files"] == 2
+        assert parsed["successful"] == 1
+        assert parsed["failed"] == 1
+        assert len(parsed["errors"]) == 1
+
+    def test_batch_empty_list(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "out"
+        result = batch_modify_pdf_content([], str(output_dir), {"a": "b"})
+        parsed = json.loads(result)
+        assert parsed["total_files"] == 0
+        assert parsed["successful"] == 0
+        assert parsed["failed"] == 0
+
+    def test_batch_regex(self, tmp_path: Path) -> None:
+        pdf = create_pdf(tmp_path / "test.pdf", text="Date: 2024-01-01")
+        output_dir = tmp_path / "out"
+
+        result = batch_modify_pdf_content(
+            [str(pdf)],
+            str(output_dir),
+            {r"\d{4}-\d{2}-\d{2}": "REDACTED"},
+            use_regex=True,
+        )
+        parsed = json.loads(result)
+        assert parsed["successful"] == 1
 
 
 class TestMCPErrorHandling:


### PR DESCRIPTION
## Summary
- New `batch_process()` core function for processing multiple PDFs with the same replacements
- New `batch_modify_pdf_content` MCP tool for LLM-driven batch operations
- New `batch` CLI command with Rich table output showing per-file results
- Per-file error isolation: one failure doesn't stop the batch
- `BatchResult` model with aggregate stats (total, successful, failed)

## Test plan
- [x] 7 unit tests for `batch_process()` (multiple files, failed files, empty list, regex, output dir, same-input-output skip)
- [x] 4 MCP tool tests (multiple files, missing file, empty list, regex)
- [x] 4 CLI tests (multiple files, failed file output, invalid format, help)
- [x] `make check` passes: 129 tests, 88.44% coverage

Closes #11